### PR TITLE
add configurable base image node version

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #Format is MAJOR . MINOR . PATCH
 
-IMAGE_VERSION=0.1.16
+IMAGE_VERSION=0.1.17
 
 
 test-build-and-package: test-source build-and-package

--- a/pkg/kiln/io.go
+++ b/pkg/kiln/io.go
@@ -226,7 +226,7 @@ func (sourceInfo *SourceInfo) Clean() error {
 }
 
 //The TEMPLATE for generating a go file
-const templateString = `FROM mhart/alpine-node:4
+const templateString = `FROM mhart/alpine-node:{{.NodeVersion}}
 
 ADD . .
 RUN npm install

--- a/pkg/kiln/types.go
+++ b/pkg/kiln/types.go
@@ -12,6 +12,7 @@ type DockerInfo struct {
 	ImageName string
 	Revision  string
 	EnvVars   []string
+	NodeVersion string
 }
 
 //GetImageName generate an image of the format {RepoName}/{ImageName}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -177,6 +177,7 @@ func (server *Server) postApplication(w http.ResponseWriter, r *http.Request) {
 		ImageName: createImage.Application,
 		Revision:  createImage.Revision,
 		EnvVars:   createImage.EnvVars,
+		NodeVersion: createImage.NodeVersion,
 	}
 
 	//check if the image exists, if it does, return a 409

--- a/pkg/server/types.go
+++ b/pkg/server/types.go
@@ -8,6 +8,8 @@ import (
 )
 
 var regex = regexp.MustCompile(`\d+:\/[\w+(\/)?]?`)
+// DefaultNodeVersion the default version of alpine-node image
+const DefaultNodeVersion = "4"
 
 //Image represents an image struct
 type Image struct {
@@ -39,6 +41,7 @@ type CreateImage struct {
 	Revision    string `schema:"revision"`
 	PublicPath  string `schema:"publicPath"`
 	EnvVars     []string `schema:"envVar"`
+	NodeVersion string `schema:"nodeVersion"`
 }
 
 //Validate validate the application input is correct
@@ -65,6 +68,10 @@ func (createImage *CreateImage) Validate() *Validation {
 
 	if !regex.Match([]byte(createImage.PublicPath)) {
 		errors.Add("PublicPath", "Public path must match the format of [PORT]:/[URL SEGMENT/]?")
+	}
+
+	if createImage.NodeVersion == "" {
+		createImage.NodeVersion = DefaultNodeVersion // default to alpine-node:4
 	}
 
 	return errors


### PR DESCRIPTION
Fixes backend part of [#166](https://github.com/30x/project-management/issues/166)

* add support for parsing NodeVersion parameter for image creation
* list of available Node.js base image versions are [here](https://github.com/mhart/alpine-node)
* defaults to `mhart/alpine-node:4` if not present in API call
* bumps kiln image version to 0.1.17