### PR TITLE
Add Docker Registry support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 #Format is MAJOR . MINOR . PATCH
 
-IMAGE_VERSION=0.1.18
+IMAGE_VERSION=0.1.20
 
 
 test-build-and-package: test-source build-and-package
@@ -49,4 +49,4 @@ push-to-hub:
 	docker push thirtyx/kiln:$(IMAGE_VERSION)
 
 run-dev:
-	env DEPLOY_STATE=DEV NO_REAP="true" PORT=5280 SHUTDOWN_TIMEOUT="0" DOCKER_PROVIDER=docker DOCKER_REGISTRY_URL="localhost:5000" ORG_LABEL=org APP_NAME_LABEL=app go run main.go
+	env AUTH_API_HOST="https://api.e2e.apigee.net/" REGISTRY_API_SERVER="http://api.shipyard.dev:31222" DEPLOY_STATE=DEV NO_REAP="true" PORT=5280 SHUTDOWN_TIMEOUT="0" DOCKER_PROVIDER=private DOCKER_REGISTRY_URL="localhost:5000" ORG_LABEL=org APP_NAME_LABEL=app go run main.go

--- a/kubernetes/gcp-dep.yaml
+++ b/kubernetes/gcp-dep.yaml
@@ -1,0 +1,82 @@
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: kiln
+  labels:
+    name: kiln
+  namespace: shipyard
+spec:
+  replicas: 1
+  template:
+    metadata:
+      labels:
+        name: kiln
+        edge/routable: "true"
+      annotations:
+        edge/paths: '[{"basePath": "/organizations", "containerPort": "5280"}]'
+    spec:
+      containers:
+      - image: thirtyx/kiln:dev
+        imagePullPolicy: Always
+        name: kiln
+        livenessProbe:
+          failureThreshold: 3
+          httpGet:
+            path: /organizations/status
+            port: 5280
+            scheme: HTTP
+          initialDelaySeconds: 15
+          periodSeconds: 30
+          successThreshold: 1
+          timeoutSeconds: 1
+        ports:
+        - containerPort: 5280
+        env:
+        - name: PORT
+          value: "5280"
+        - name: DEPLOY_STATE
+          value: "DEV_CONTAINER"
+        - name: DOCKER_PROVIDER
+          value: gcr
+        - name: DOCKER_REGISTRY_URL
+          value: gcr.io
+        - name: REGISTRY_API_SERVER
+          value: https://gcr.io
+        - name: DOCKER_HOST
+          value: unix:///var/run/docker.sock
+        - name: SHUTDOWN_TIMEOUT
+          value: "60"
+        - name: REAP_INTERVAL
+          value: "60"
+          # Leave images < 5 minutes old
+        - name: REAP_MIN_AGE
+          value: "300"
+        - name: AUTH_API_HOST
+          valueFrom:
+            configMapKeyRef:
+              name: shipyard-config
+              key: AUTH_API_HOST
+        - name: ORG_LABEL
+          valueFrom:
+            configMapKeyRef:
+              name: shipyard-config
+              key: ORG_LABEL
+        - name: APP_NAME_LABEL
+          valueFrom:
+            configMapKeyRef:
+              name: shipyard-config
+              key: APP_NAME_LABEL
+        - name: APP_REV_LABEL
+          valueFrom:
+            configMapKeyRef:
+              name: shipyard-config
+              key: APP_REV_LABEL
+        volumeMounts:
+        - mountPath: /var/run/docker.sock
+          name: dockersocket
+          readOnly: false
+
+      volumes:
+      - name: dockersocket
+        hostPath:
+          path: /var/run/docker.sock

--- a/pkg/kiln/docker.go
+++ b/pkg/kiln/docker.go
@@ -30,7 +30,4 @@ type ImageCreator interface {
 
 	//PushImage pushes the remotely tagged image to docker. Returns a reader of the stream, or an error
 	PushImage(dockerInfo *DockerInfo) (chan (string), error)
-
-	//GenerateRepoURI Generate the absolute repo uri from the docker info
-	GenerateRepoURI(dockerInfo *DockerInfo) string
 }

--- a/pkg/kiln/docker_ecs.go
+++ b/pkg/kiln/docker_ecs.go
@@ -364,11 +364,6 @@ func (imageCreator EcsImageCreator) PushImage(dockerInfo *DockerInfo) (chan (str
 	return imageCreator.dockerCreator.PushImage(dockerInfo)
 }
 
-//GenerateRepoURI generate the repo uri
-func (imageCreator EcsImageCreator) GenerateRepoURI(dockerInfo *DockerInfo) string {
-	return imageCreator.dockerCreator.GenerateRepoURI(dockerInfo)
-}
-
 //return true if the image exists
 func (imageCreator EcsImageCreator) imageExists(imageName string) (bool, error) {
 	describeRequest := &ecr.DescribeRepositoriesInput{

--- a/pkg/kiln/docker_registry.go
+++ b/pkg/kiln/docker_registry.go
@@ -1,0 +1,145 @@
+package kiln
+
+import (
+	"fmt"
+
+	"github.com/30x/kiln/pkg/registry"
+	"github.com/docker/engine-api/types"
+)
+
+//RegistryImageCreator is a struct that holds our pointer to the docker client
+type RegistryImageCreator struct {
+	//the client to docker
+	client registry.Registry
+	//the remote repository url
+	dockerCreator ImageCreator
+}
+
+//NewRegistryImageCreator creates an instance of the RegistryImageCreator from the docker environment variables, and returns the instance
+func NewRegistryImageCreator(repo string, reg registry.Registry) (ImageCreator, error) {
+	// necessary for using a GCR registry, the project name needs to be in the image tag
+	// and tagging is done by the LocalImageCreator before push
+	if proj := reg.GetProjectName(); proj != "" {
+		repo = fmt.Sprintf("%s/%s", repo, proj)
+	}
+
+	localDocker, err := NewLocalImageCreator(repo)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &RegistryImageCreator{
+		client:        reg,
+		dockerCreator: localDocker,
+	}, nil
+}
+
+// GetOrganizations retrieves image repos in the registry
+func (imageCreator RegistryImageCreator) GetOrganizations() (*[]string, error) {
+	return nil, fmt.Errorf("GetOrganizations is unsupported for private registries at this time")
+}
+
+//GetApplications get all remote application for the specified repository
+func (imageCreator RegistryImageCreator) GetApplications(repository string) (*[]string, error) {
+	apps, err := imageCreator.client.ListRepositories(repository)
+
+	if err != nil {
+		return nil, err
+	}
+
+	return &apps, nil
+}
+
+//GetLocalImages return all local images
+func (imageCreator RegistryImageCreator) GetLocalImages() (*[]types.Image, error) {
+	return imageCreator.dockerCreator.GetLocalImages()
+}
+
+//BuildImage build the image
+func (imageCreator RegistryImageCreator) BuildImage(dockerInfo *DockerBuild) (chan (string), error) {
+	return imageCreator.dockerCreator.BuildImage(dockerInfo)
+}
+
+// PushImage pushes the iamge
+func (imageCreator RegistryImageCreator) PushImage(dockerInfo *DockerInfo) (chan (string), error) {
+	return imageCreator.dockerCreator.PushImage(dockerInfo)
+}
+
+//DeleteApplication Delete all images of the application from the remote repository.  Return an error if unable to do so.
+func (imageCreator RegistryImageCreator) DeleteApplication(dockerInfo *DockerInfo, images *[]types.Image) error {
+	name := fmt.Sprintf("%s/%s", dockerInfo.RepoName, dockerInfo.ImageName)
+
+	for _, image := range *images {
+		err := imageCreator.client.DeleteImageManifest(name, image.ID)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+//DeleteImageRevisionLocal Delete the image revision from the local repo
+func (imageCreator RegistryImageCreator) DeleteImageRevisionLocal(sha string) error {
+	//just delegate to the local docker impl
+	return imageCreator.dockerCreator.DeleteImageRevisionLocal(sha)
+}
+
+//GetImageRevision get the image revision
+func (imageCreator RegistryImageCreator) GetImageRevision(dockerInfo *DockerInfo) (*types.Image, error) {
+
+	name := fmt.Sprintf("%s/%s", dockerInfo.RepoName, dockerInfo.ImageName)
+	tag := dockerInfo.Revision
+
+	blobDigest, _, err := imageCreator.client.GetImageBlobDigest(name, tag)
+	if err != nil {
+		return nil, err
+	}
+
+	blob, err := imageCreator.client.GetImageBlob(name, blobDigest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &types.Image{
+		Created:  blob.Created.Unix(),
+		RepoTags: []string{fmt.Sprintf("%s:%s", name, tag)},
+		ID:       blobDigest,
+		Labels:   blob.Config.Labels,
+	}, nil
+
+}
+
+//GetImages get all the images for the specified repository and application
+func (imageCreator RegistryImageCreator) GetImages(repository string, application string) (*[]types.Image, error) {
+
+	name := fmt.Sprintf("%s/%s", repository, application)
+
+	tags, err := imageCreator.client.ListImageTags(name)
+	if err != nil {
+		return nil, err
+	}
+
+	images := make([]types.Image, len(tags))
+	for ndx, tag := range tags {
+		blobDigest, manifestDigest, err := imageCreator.client.GetImageBlobDigest(name, tag)
+		if err != nil {
+			return nil, err
+		}
+
+		blob, err := imageCreator.client.GetImageBlob(name, blobDigest)
+		if err != nil {
+			return nil, err
+		}
+
+		images[ndx] = types.Image{
+			Created:  blob.Created.Unix(),
+			RepoTags: []string{fmt.Sprintf("%s:%s", name, tag)},
+			ID:       manifestDigest, //we return this so that this can be used to delete apps
+			Labels:   blob.Config.Labels,
+		}
+	}
+
+	return &images, nil
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -1,0 +1,29 @@
+package registry
+
+// Registry generic interface for interacting with a Docker Registry
+type Registry interface {
+
+	// ListRepositories lists the image repositories under the given name (usually a registry/project name)
+	ListRepositories(name string) ([]string, error)
+
+	// ListImageTags lists all available image tags for the given name
+	ListImageTags(name string) ([]string, error)
+
+	// GetImageBlobDigest retrieves an image's unique blob digest, as well as the manifest digest b.c we get that for free, based on the name and tag
+	GetImageBlobDigest(name, tag string) (string, string, error)
+
+	// GetImageManifestDigest retrieves an image's unique manifest digest based on the name and tag
+	GetImageManifestDigest(name, tag string) (string, error)
+
+	// GetImageBlob retrieves the blob (details) for the image specified by name and reference
+	GetImageBlob(name, reference string) (*ImageBlob, error)
+
+	// GetImageManifest retrieves the manifest for the given image name & tag
+	GetImageManifest(name, tag string) (*ManifestResponse, error)
+
+	// DeleteImageManifest deletes the image identified by the name and tag
+	DeleteImageManifest(name, reference string) error
+
+	// GetProjectName returns the GCR Project Name, private registry doesn't have this property
+	GetProjectName() string
+}

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -24,6 +24,9 @@ type Registry interface {
 	// DeleteImageManifest deletes the image identified by the name and tag
 	DeleteImageManifest(name, reference string) error
 
+	// DeleteImageTag deletes the image's tag
+	DeleteImageTag(name, tag string) error
+
 	// GetProjectName returns the GCR Project Name, private registry doesn't have this property
 	GetProjectName() string
 }

--- a/pkg/registry/registry_gcr.go
+++ b/pkg/registry/registry_gcr.go
@@ -1,0 +1,264 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"net/http"
+
+	"golang.org/x/net/context"
+	"golang.org/x/oauth2/google"
+)
+
+// GoogleContainerRegistry represents the Google Container Registry implementation of the remote Registry interface
+type GoogleContainerRegistry struct {
+	ProjectName string
+	RegistryURL string
+	Client      *http.Client
+}
+
+// NewGoogleContainerRegistryClient returns a newly configured Google Container Registry client
+func NewGoogleContainerRegistryClient(registryURL string) (Registry, error) {
+	ctx := context.Background()
+
+	//Get our authn'd client
+	client, err := google.DefaultClient(ctx)
+	if err != nil {
+		fmt.Printf("Error getting GCR client: %v\n", err)
+		return nil, err
+	}
+
+	if registryURL == "" {
+		registryURL = "https://gcr.io"
+	}
+
+	projectName, err := getGCPProjectName()
+	if err != nil {
+		return nil, err
+	}
+
+	return &GoogleContainerRegistry{
+		ProjectName: projectName,
+		RegistryURL: registryURL,
+		Client:      client,
+	}, nil
+}
+
+func getGCPProjectName() (string, error) {
+	// curl -H "Metadata-Flavor: Google" http://metadata.google.internal/computeMetadata/v1/project/project-id
+	req, err := http.NewRequest(http.MethodGet, "http://metadata.google.internal/computeMetadata/v1/project/project-id", nil)
+	if err != nil {
+		return "", err
+	}
+
+	req.Header.Add("Metadata-Flavor", "Google")
+
+	res, err := http.DefaultClient.Do(req)
+	if err != nil {
+		return "", err
+	}
+
+	defer res.Body.Close()
+	data, _ := ioutil.ReadAll(res.Body)
+
+	return string(data), nil
+}
+
+// GetProjectName returns the project name for this client
+func (reg *GoogleContainerRegistry) GetProjectName() string {
+	return reg.ProjectName
+}
+
+func (reg *GoogleContainerRegistry) getRegistryURLWithAPIVersionV2() string {
+	return fmt.Sprintf("%s/v2", reg.RegistryURL)
+}
+
+// ListRepositories lists the image repos built under the given name
+func (reg *GoogleContainerRegistry) ListRepositories(name string) ([]string, error) {
+	// GCR /v2/_catalog support is weird, using their extended /tags/list functionality in the mean time
+	target := fmt.Sprintf("%s/%s/%s/tags/list", reg.getRegistryURLWithAPIVersionV2(), reg.ProjectName, name)
+
+	res, err := reg.Client.Get(target)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	defer res.Body.Close()
+	decoder := json.NewDecoder(res.Body)
+
+	repos := ListReposResponse{}
+	err = decoder.Decode(&repos)
+	if err != nil {
+		return nil, err
+	}
+
+	return repos.Child, nil
+}
+
+// ListImageTags lists the available tags for an image
+func (reg *GoogleContainerRegistry) ListImageTags(name string) ([]string, error) {
+	target := fmt.Sprintf("%s/%s/%s/tags/list", reg.getRegistryURLWithAPIVersionV2(), reg.ProjectName, name)
+
+	res, err := reg.Client.Get(target)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	defer res.Body.Close()
+	decoder := json.NewDecoder(res.Body)
+
+	tags := ListTagsResponse{}
+	err = decoder.Decode(&tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return tags.Tags, nil
+}
+
+// GetImageBlob retrieves an image blob specified by the name and reference
+func (reg *GoogleContainerRegistry) GetImageBlob(name, reference string) (*ImageBlob, error) {
+	target := fmt.Sprintf("%s/%s/%s/blobs/%s", reg.getRegistryURLWithAPIVersionV2(), reg.ProjectName, name, reference)
+
+	res, err := reg.Client.Get(target)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	defer res.Body.Close()
+	decoder := json.NewDecoder(res.Body)
+
+	blob := ImageBlob{}
+	err = decoder.Decode(&blob)
+	if err != nil {
+		return nil, err
+	}
+
+	return &blob, nil
+}
+
+// GetImageManifest retrieves a manifest for the image given by name and tag
+func (reg *GoogleContainerRegistry) GetImageManifest(name, tag string) (*ManifestResponse, error) {
+	target := fmt.Sprintf("%s/%s/%s/manifests/%s", reg.getRegistryURLWithAPIVersionV2(), reg.ProjectName, name, tag)
+
+	req, err := http.NewRequest(http.MethodGet, target, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// need this header to get the correct digest
+	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+
+	res, err := reg.Client.Do(req)
+	if err != nil {
+		return nil, nil
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	defer res.Body.Close()
+	decoder := json.NewDecoder(res.Body)
+
+	manifest := ManifestResponse{}
+	err = decoder.Decode(&manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &manifest, nil
+}
+
+// DeleteImageManifest deletes the image manifest identified by the name and reference
+// Note: the reference must be the manifest's digest, or it will only delete the tag
+func (reg *GoogleContainerRegistry) DeleteImageManifest(name, reference string) error {
+	target := fmt.Sprintf("%s/%s/%s/manifests/%s", reg.getRegistryURLWithAPIVersionV2(), reg.ProjectName, name, reference)
+
+	req, err := http.NewRequest(http.MethodDelete, target, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+
+	res, err := reg.Client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	return nil
+}
+
+// GetImageManifestDigest retrieves the image's manifest digest
+func (reg *GoogleContainerRegistry) GetImageManifestDigest(name, tag string) (string, error) {
+	target := fmt.Sprintf("%s/%s/%s/manifests/%s", reg.getRegistryURLWithAPIVersionV2(), reg.ProjectName, name, tag)
+
+	req, err := http.NewRequest(http.MethodHead, target, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// need this header to get the correct digest
+	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+
+	res, err := reg.Client.Do(req)
+	if err != nil {
+		return "", nil
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	return res.Header.Get("Docker-Content-Digest"), nil
+}
+
+// GetImageBlobDigest retrieves the digest for the blob of the specified name and tag
+func (reg *GoogleContainerRegistry) GetImageBlobDigest(name, tag string) (string, string, error) {
+	target := fmt.Sprintf("%s/%s/%s/manifests/%s", reg.getRegistryURLWithAPIVersionV2(), reg.ProjectName, name, tag)
+
+	req, err := http.NewRequest(http.MethodGet, target, nil)
+	if err != nil {
+		return "", "", err
+	}
+
+	// need this header to get the correct digest
+	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+
+	res, err := reg.Client.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	defer res.Body.Close()
+	decoder := json.NewDecoder(res.Body)
+
+	manifest := ManifestResponse{}
+	err = decoder.Decode(&manifest)
+	if err != nil {
+		return "", "", err
+	}
+
+	return manifest.Config.Digest, res.Header.Get("Docker-Content-Digest"), nil
+}

--- a/pkg/registry/registry_gcr.go
+++ b/pkg/registry/registry_gcr.go
@@ -84,7 +84,7 @@ func (reg *GoogleContainerRegistry) ListRepositories(name string) ([]string, err
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+		return nil, fmt.Errorf("Non-OK status code received in ListRepositories: %d", res.StatusCode)
 	}
 
 	defer res.Body.Close()
@@ -109,7 +109,7 @@ func (reg *GoogleContainerRegistry) ListImageTags(name string) ([]string, error)
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+		return nil, fmt.Errorf("Non-OK status code received in ListImageTags: %d", res.StatusCode)
 	}
 
 	defer res.Body.Close()
@@ -134,7 +134,7 @@ func (reg *GoogleContainerRegistry) GetImageBlob(name, reference string) (*Image
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+		return nil, fmt.Errorf("Non-OK status code received in GetImageBlob: %d", res.StatusCode)
 	}
 
 	defer res.Body.Close()
@@ -167,7 +167,7 @@ func (reg *GoogleContainerRegistry) GetImageManifest(name, tag string) (*Manifes
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+		return nil, fmt.Errorf("Non-OK status code received in GetImageManifest: %d", res.StatusCode)
 	}
 
 	defer res.Body.Close()
@@ -199,8 +199,8 @@ func (reg *GoogleContainerRegistry) DeleteImageManifest(name, reference string) 
 		return err
 	}
 
-	if res.StatusCode != http.StatusAccepted {
-		return fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("Non-OK status code received in DeleteImageManifest: %d", res.StatusCode)
 	}
 
 	return nil
@@ -224,7 +224,7 @@ func (reg *GoogleContainerRegistry) GetImageManifestDigest(name, tag string) (st
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+		return "", fmt.Errorf("Non-OK status code received in GetImageManifestDigest: %d", res.StatusCode)
 	}
 
 	return res.Header.Get("Docker-Content-Digest"), nil
@@ -248,7 +248,7 @@ func (reg *GoogleContainerRegistry) GetImageBlobDigest(name, tag string) (string
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+		return "", "", fmt.Errorf("Non-OK status code received in GetImageBlobDigest: %d", res.StatusCode)
 	}
 
 	defer res.Body.Close()
@@ -261,4 +261,27 @@ func (reg *GoogleContainerRegistry) GetImageBlobDigest(name, tag string) (string
 	}
 
 	return manifest.Config.Digest, res.Header.Get("Docker-Content-Digest"), nil
+}
+
+// DeleteImageTag deletes the image's specified tag
+func (reg *GoogleContainerRegistry) DeleteImageTag(name, tag string) error {
+	target := fmt.Sprintf("%s/%s/%s/manifests/%s", reg.getRegistryURLWithAPIVersionV2(), reg.ProjectName, name, tag)
+
+	req, err := http.NewRequest(http.MethodDelete, target, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+
+	res, err := reg.Client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return fmt.Errorf("Non-OK status code received in DeleteImageTag: %d", res.StatusCode)
+	}
+
+	return nil
 }

--- a/pkg/registry/registry_private.go
+++ b/pkg/registry/registry_private.go
@@ -50,7 +50,7 @@ func (reg *PrivateRegistry) ListRepositories(name string) ([]string, error) {
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+		return nil, fmt.Errorf("Non-OK status code received in ListRepositories: %d", res.StatusCode)
 	}
 
 	defer res.Body.Close()
@@ -80,7 +80,7 @@ func (reg *PrivateRegistry) ListImageTags(name string) ([]string, error) {
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+		return nil, fmt.Errorf("Non-OK status code received in ListImageTags: %d", res.StatusCode)
 	}
 
 	defer res.Body.Close()
@@ -105,7 +105,7 @@ func (reg *PrivateRegistry) GetImageBlob(name, reference string) (*ImageBlob, er
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+		return nil, fmt.Errorf("Non-OK status code received in GetImageBlob: %d", res.StatusCode)
 	}
 
 	defer res.Body.Close()
@@ -138,7 +138,7 @@ func (reg *PrivateRegistry) GetImageManifest(name, tag string) (*ManifestRespons
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+		return nil, fmt.Errorf("Non-OK status code received in GetImageManifest: %d", res.StatusCode)
 	}
 
 	defer res.Body.Close()
@@ -171,7 +171,7 @@ func (reg *PrivateRegistry) DeleteImageManifest(name, reference string) error {
 	}
 
 	if res.StatusCode != http.StatusAccepted {
-		return fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+		return fmt.Errorf("Non-OK status code received in DeleteImageManifest: %d", res.StatusCode)
 	}
 
 	return nil
@@ -195,7 +195,7 @@ func (reg *PrivateRegistry) GetImageManifestDigest(name, tag string) (string, er
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return "", fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+		return "", fmt.Errorf("Non-OK status code received in GetImageManifestDigest: %d", res.StatusCode)
 	}
 
 	return res.Header.Get("Docker-Content-Digest"), nil
@@ -219,7 +219,7 @@ func (reg *PrivateRegistry) GetImageBlobDigest(name, tag string) (string, string
 	}
 
 	if res.StatusCode != http.StatusOK {
-		return "", "", fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+		return "", "", fmt.Errorf("Non-OK status code received in GetImageBlobDigest: %d", res.StatusCode)
 	}
 
 	defer res.Body.Close()
@@ -237,4 +237,9 @@ func (reg *PrivateRegistry) GetImageBlobDigest(name, tag string) (string, string
 // GetProjectName returns an empty string b.c this is only needed for GCR
 func (reg *PrivateRegistry) GetProjectName() string {
 	return ""
+}
+
+// DeleteImageTag deletes the image's specified tag
+func (reg *PrivateRegistry) DeleteImageTag(name, tag string) error {
+	return fmt.Errorf("Deleting an image manfiest by tag is not supported in a private registry")
 }

--- a/pkg/registry/registry_private.go
+++ b/pkg/registry/registry_private.go
@@ -1,0 +1,240 @@
+package registry
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"os"
+)
+
+// PrivateRegistry represents a private Docker Registry client
+type PrivateRegistry struct {
+	RegistryURL string
+	Client      *http.Client
+	AuthScheme  string
+	AuthToken   string
+}
+
+// NewPrivateRegistryClient creates a client for use with a private Docker Registry
+func NewPrivateRegistryClient(registryURL string) Registry {
+	reg := PrivateRegistry{}
+
+	// if these are empty, they won't be used later on
+	// TODO: figure out how to use golang.org/x/oauth2 to build client
+	reg.AuthScheme = os.Getenv("REGISTRY_AUTH_SCHEME")
+	reg.AuthToken = os.Getenv("REGISTRY_AUTH_TOKEN")
+
+	reg.Client = http.DefaultClient
+	reg.RegistryURL = registryURL
+
+	return &reg
+}
+
+func (reg *PrivateRegistry) getRegistryURLWithAPIVersionV2() string {
+	return fmt.Sprintf("%s/v2", reg.RegistryURL)
+}
+
+func (reg *PrivateRegistry) checkAndAddAuth(req *http.Request) {
+	if reg.AuthScheme != "" && reg.AuthToken != "" {
+		req.Header.Add("Authorization", reg.AuthScheme+" "+reg.AuthToken)
+	}
+}
+
+// ListRepositories lists the image repos built under the given name
+func (reg *PrivateRegistry) ListRepositories(name string) ([]string, error) {
+	target := fmt.Sprintf("%s/_catalog", reg.getRegistryURLWithAPIVersionV2())
+
+	res, err := reg.Client.Get(target)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	defer res.Body.Close()
+	decoder := json.NewDecoder(res.Body)
+
+	repos := CatalogResponse{}
+	err = decoder.Decode(&repos)
+	if err != nil {
+		return nil, err
+	}
+
+	if name != "" {
+		// need to filter results by name
+		return filterReposByRootName(repos.Repositories, name), nil
+	}
+
+	return repos.Repositories, nil
+}
+
+// ListImageTags lists the available tags for an image
+func (reg *PrivateRegistry) ListImageTags(name string) ([]string, error) {
+	target := fmt.Sprintf("%s/%s/tags/list", reg.getRegistryURLWithAPIVersionV2(), name)
+
+	res, err := reg.Client.Get(target)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	defer res.Body.Close()
+	decoder := json.NewDecoder(res.Body)
+
+	tags := ListTagsResponse{}
+	err = decoder.Decode(&tags)
+	if err != nil {
+		return nil, err
+	}
+
+	return tags.Tags, nil
+}
+
+// GetImageBlob retrieves an image blob specified by the name and reference
+func (reg *PrivateRegistry) GetImageBlob(name, reference string) (*ImageBlob, error) {
+	target := fmt.Sprintf("%s/%s/blobs/%s", reg.getRegistryURLWithAPIVersionV2(), name, reference)
+
+	res, err := reg.Client.Get(target)
+	if err != nil {
+		return nil, err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	defer res.Body.Close()
+	decoder := json.NewDecoder(res.Body)
+
+	blob := ImageBlob{}
+	err = decoder.Decode(&blob)
+	if err != nil {
+		return nil, err
+	}
+
+	return &blob, nil
+}
+
+// GetImageManifest retrieves a manifest for the image given by name and tag
+func (reg *PrivateRegistry) GetImageManifest(name, tag string) (*ManifestResponse, error) {
+	target := fmt.Sprintf("%s/%s/manifests/%s", reg.getRegistryURLWithAPIVersionV2(), name, tag)
+
+	req, err := http.NewRequest(http.MethodGet, target, nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// need this header to get the correct digest
+	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+
+	res, err := reg.Client.Do(req)
+	if err != nil {
+		return nil, nil
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	defer res.Body.Close()
+	decoder := json.NewDecoder(res.Body)
+
+	manifest := ManifestResponse{}
+	err = decoder.Decode(&manifest)
+	if err != nil {
+		return nil, err
+	}
+
+	return &manifest, nil
+}
+
+// DeleteImageManifest deletes the image manifest identified by the name and reference
+// Note: the reference must be the manifest's digest, or it will only delete the tag
+func (reg *PrivateRegistry) DeleteImageManifest(name, reference string) error {
+	target := fmt.Sprintf("%s/%s/manifests/%s", reg.getRegistryURLWithAPIVersionV2(), name, reference)
+
+	req, err := http.NewRequest(http.MethodDelete, target, nil)
+	if err != nil {
+		return err
+	}
+
+	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+
+	res, err := reg.Client.Do(req)
+	if err != nil {
+		return err
+	}
+
+	if res.StatusCode != http.StatusAccepted {
+		return fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	return nil
+}
+
+// GetImageManifestDigest retrieves the image's manifest digest
+func (reg *PrivateRegistry) GetImageManifestDigest(name, tag string) (string, error) {
+	target := fmt.Sprintf("%s/%s/manifests/%s", reg.getRegistryURLWithAPIVersionV2(), name, tag)
+
+	req, err := http.NewRequest(http.MethodHead, target, nil)
+	if err != nil {
+		return "", err
+	}
+
+	// need this header to get the correct digest
+	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+
+	res, err := reg.Client.Do(req)
+	if err != nil {
+		return "", nil
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return "", fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	return res.Header.Get("Docker-Content-Digest"), nil
+}
+
+// GetImageBlobDigest retrieves the digest for the blob of the specified name and tag
+func (reg *PrivateRegistry) GetImageBlobDigest(name, tag string) (string, string, error) {
+	target := fmt.Sprintf("%s/%s/manifests/%s", reg.getRegistryURLWithAPIVersionV2(), name, tag)
+
+	req, err := http.NewRequest(http.MethodGet, target, nil)
+	if err != nil {
+		return "", "", err
+	}
+
+	// need this header to get the correct digest
+	req.Header.Add("Accept", "application/vnd.docker.distribution.manifest.v2+json")
+
+	res, err := reg.Client.Do(req)
+	if err != nil {
+		return "", "", err
+	}
+
+	if res.StatusCode != http.StatusOK {
+		return "", "", fmt.Errorf("Non-OK status code received: %d", res.StatusCode)
+	}
+
+	defer res.Body.Close()
+	decoder := json.NewDecoder(res.Body)
+
+	manifest := ManifestResponse{}
+	err = decoder.Decode(&manifest)
+	if err != nil {
+		return "", "", err
+	}
+
+	return manifest.Config.Digest, res.Header.Get("Docker-Content-Digest"), nil
+}
+
+// GetProjectName returns an empty string b.c this is only needed for GCR
+func (reg *PrivateRegistry) GetProjectName() string {
+	return ""
+}

--- a/pkg/registry/types.go
+++ b/pkg/registry/types.go
@@ -1,0 +1,87 @@
+package registry
+
+import "time"
+
+// ListTagsResponse represents the response from /tags/list
+type ListTagsResponse struct {
+	Name string   `json:"name"`
+	Tags []string `json:"tags,omitempty"`
+}
+
+// CatalogResponse represents the reponse from a list of image repos
+type CatalogResponse struct {
+	Repositories []string `json:"repositories"`
+}
+
+// ListReposResponse here the child property represents the iamges built under the project
+// this is based on GCR's extended /tags/list functionality
+type ListReposResponse struct {
+	Child    []string    `json:"child,omitempty"`
+	Manifest interface{} `json:"manifest,omitempty"`
+	Name     string      `json:"name"`
+	Tags     []string    `json:"tags,omitempty"`
+}
+
+type ManifestConfig struct {
+	MediaType string `json:"mediaType"`
+	Size      int    `json:"size"`
+	Digest    string `json:"digest"`
+}
+
+type ManifestLayer struct {
+	MediaType string   `json:"mediaType"`
+	Size      int      `json:"size"`
+	Digest    string   `json:"digest"`
+	URLs      []string `json:"urls,omitempty"`
+}
+
+type ManifestResponse struct {
+	SchemaVersion int             `json:"schemaVersion"`
+	MediaType     string          `json:"mediaType"`
+	Config        ManifestConfig  `json:"config"`
+	Layers        []ManifestLayer `json:"layers"`
+}
+
+type ImageBlob struct {
+	Architecture    string        `json:"architecture"`
+	Config          BlobConfig    `json:"config"`
+	Container       string        `json:"container"`
+	ContainerConfig BlobConfig    `json:"container_config"`
+	Created         time.Time     `json:"created"`
+	DockerVersion   string        `json:"docker_version"`
+	History         []BlobHistory `json:"history"`
+	Os              string        `json:"os"`
+	Rootfs          BlobRootFS    `json:"rootfs"`
+}
+
+type BlobConfig struct {
+	ArgsEscaped  bool              `json:"ArgsEscaped"`
+	AttachStderr bool              `json:"AttachStderr"`
+	AttachStdin  bool              `json:"AttachStdin"`
+	AttachStdout bool              `json:"AttachStdout"`
+	Cmd          []string          `json:"Cmd"`
+	Domainname   string            `json:"Domainname"`
+	Entrypoint   interface{}       `json:"Entrypoint"`
+	Env          []string          `json:"Env"`
+	Hostname     string            `json:"Hostname"`
+	Image        string            `json:"Image"`
+	Labels       map[string]string `json:"Labels"`
+	OnBuild      []interface{}     `json:"OnBuild"`
+	OpenStdin    bool              `json:"OpenStdin"`
+	StdinOnce    bool              `json:"StdinOnce"`
+	Tty          bool              `json:"Tty"`
+	User         string            `json:"User"`
+	Volumes      interface{}       `json:"Volumes"`
+	WorkingDir   string            `json:"WorkingDir"`
+}
+
+type BlobHistory struct {
+	Created    time.Time `json:"created"`
+	CreatedBy  string    `json:"created_by"`
+	EmptyLayer bool      `json:"empty_layer,omitempty"`
+}
+
+type BlobRootFS struct {
+	DiffIds []string `json:"diff_ids"`
+	Type    string   `json:"type"`
+}

--- a/pkg/registry/util.go
+++ b/pkg/registry/util.go
@@ -1,0 +1,14 @@
+package registry
+
+import "strings"
+
+func filterReposByRootName(repos []string, name string) (filtered []string) {
+	for _, repo := range repos {
+		nameEnd := strings.Index(repo, "/")
+		if name == repo[:nameEnd] {
+			filtered = append(filtered, repo)
+		}
+	}
+
+	return
+}


### PR DESCRIPTION
* adds `kiln` implementation with Docker Registry API
* `registry` pkg supports GCR and Private Docker Registry backends
* adds support for pushing images to GCR while deployed on GCE

Fixes #92 
Fixes #87 
Fixes [#6](https://github.com/30x/shipyard/issues/6)