### PR TITLE
remove fail on build err

### DIFF
--- a/pkg/kiln/docker_repo.go
+++ b/pkg/kiln/docker_repo.go
@@ -261,7 +261,7 @@ func (imageCreator LocalImageCreator) BuildImage(dockerInfo *DockerBuild) (chan 
 	response, err := imageCreator.client.ImageBuild(context.Background(), imageBuildOptions)
 
 	if err != nil {
-		LogInfo.Fatal(err)
+		LogError.Println(err)
 		return nil, err
 	}
 

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -266,7 +266,7 @@ func (server *Server) postApplication(w http.ResponseWriter, r *http.Request) {
 	outputChannel, err := server.imageCreator.BuildImage(dockerBuild)
 
 	if err != nil {
-		message := fmt.Sprintf("Could not build image from docker info %+v.  Error is %s", dockerInfo, err)
+		message := fmt.Sprintf("Could not build image from docker info %+v.  Error is %s", *dockerInfo, err)
 		kiln.LogError.Printf(message)
 		internalError(message, w)
 		return


### PR DESCRIPTION
Fixes #94 

Instead, just logs the error and passes it along to the server to propagate along response.